### PR TITLE
feature: Remove author name from JavaScript files

### DIFF
--- a/__tests__/test-app.js
+++ b/__tests__/test-app.js
@@ -182,15 +182,6 @@ describe('Baumeister with default options', () => {
 		]);
 	});
 
-	it('should render author name and email within the comments of JavaScript files', () => {
-		const regex = new RegExp(escapeStringRegexp('@author ' + prompts.authorName + ' <' + prompts.authorMail + '>'), '');
-		const arg = [
-			['src/app/base.js', regex],
-			['src/app/index.js', regex]
-		];
-		assert.fileContent(arg);
-	});
-
 	it('should have a valid package.json file', () => {
 		JSON.parse(fs.readFileSync('package.json'));
 	});
@@ -885,15 +876,6 @@ describe('Baumeister using --yo-rc flag', () => {
 		assert.fileContent([
 			['src/assets/scss/index.scss', /.\/variables/]
 		]);
-	});
-
-	it('should render author name and email within the comments of JavaScript files', () => {
-		const regex = new RegExp(escapeStringRegexp('@author ' + prompts.authorName + ' <' + prompts.authorMail + '>'), '');
-		const arg = [
-			['src/app/base.js', regex],
-			['src/app/index.js', regex]
-		];
-		assert.fileContent(arg);
 	});
 
 	it('should have a valid package.json file', () => {

--- a/app/templates/src/app/_base.js
+++ b/app/templates/src/app/_base.js
@@ -1,6 +1,5 @@
 /**
  * @file  Base JavaScript needed independent of the project
- * @author <%= templateProps.authorName %> <<%= templateProps.authorMail %>>
  */
 
 /**

--- a/app/templates/src/app/_index.js
+++ b/app/templates/src/app/_index.js
@@ -1,6 +1,5 @@
 /**
  * @file  JavaScript entry point of the project
- * @author <%= templateProps.authorName %> <<%= templateProps.authorMail %>>
  */
 
 import './polyfills';


### PR DESCRIPTION
Pretty much unneeded and we already got rid of it in the static version of Baumeister.